### PR TITLE
Use window.alert() since it should be defined.

### DIFF
--- a/file-explorer/node_modules/folder_view.js
+++ b/file-explorer/node_modules/folder_view.js
@@ -44,7 +44,7 @@ Folder.prototype.open = function(dir) {
   fs.readdir(dir, function(error, files) {
     if (error) {
       console.log(error);
-      alert(error);
+      window.alert(error);
       return;
     }
 

--- a/file-explorer/node_modules/mime.js
+++ b/file-explorer/node_modules/mime.js
@@ -42,7 +42,7 @@ exports.stat = function(filepath) {
       }
     }
   } catch (e) {
-    alert(e);
+    window.alert(e);
   }
 
   return result;


### PR DESCRIPTION
Running this on OS X I was getting a fatal error:

```
Uncaught node.js Error 

ReferenceError: alert is not defined
    at Object.exports.stat (/Users/amorton/projects/nw-sample-apps/file-explorer/node_modules/mime.js:45:5)
    at /Users/amorton/projects/nw-sample-apps/file-explorer/node_modules/folder_view.js:52:23
    at Object.oncomplete (fs.js:297:15)
```

![Screen Shot 2013-03-24 at 11 36 54 PM](https://f.cloud.github.com/assets/68750/296821/31e1250a-9517-11e2-81e6-46d9d4d5ca3c.png)

Using the global window object seemed to get it sorted out.
