### PR TITLE
make demos working with simple npm start command

### DIFF
--- a/file-explorer/package.json
+++ b/file-explorer/package.json
@@ -1,8 +1,11 @@
 {
   "name": "FileExplorer",
   "description": "Simple file explorer.",
-  "version": "0.1",
+  "version": "0.0.1",
   "main": "index.html",
+  "scripts": {
+    "start": "nodewebkit"
+  },
   "window": {
     "toolbar": false,
     "width": 660,

--- a/frameless-window/package.json
+++ b/frameless-window/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "Frameless Window",
+  "name": "FramelessWindow",
   "description": "Chrome platform app.",
-  "version": "0.1",
+  "version": "0.0.1",
   "main": "frameless_window.html",
+  "scripts": {
+    "start": "nodewebkit"
+  },
   "window": {
     "show": false,
     "toolbar": false,

--- a/menus/package.json
+++ b/menus/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "node-webkit menu demo",
+  "name": "node-webkit-menu-demo",
   "main": "index.html",
+  "scripts": {
+    "start": "nodewebkit"
+  },
   "window": {
     "show": false,
     "position": "center",

--- a/mini-code-edit/package.json
+++ b/mini-code-edit/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.11",
   "description": "A very small code editor.",
   "main": "main.html",
+   "scripts": {
+    "start": "nodewebkit"
+  }, 
   "window": {
     "width": 400,
     "height": 520,

--- a/mp3-encoder/package.json
+++ b/mp3-encoder/package.json
@@ -1,6 +1,9 @@
 {
   "name": "mp3-encoder",
   "main": "index.html",
+  "scripts": {
+    "start": "nodewebkit"
+  },
   "window": {
     "toolbar": false,
     "resizable": false,

--- a/webgl/package.json
+++ b/webgl/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "Hello 3D World",
-  "version": "1",
+  "name": "Hello-3D-World",
+  "version": "0.0.1",
   "main": "index.html",
+  "scripts": {
+    "start": "nodewebkit"
+  },
   "window": {
     "frame": false,
     "width": 500,


### PR DESCRIPTION
Looking for node-webkit examples I found that node-webkit can be installed using npm. And in its documentation page https://www.npmjs.org/package/nodewebkit your repository was listed as example. I tried to run demos but found that it is not possible to run it most simple way using `npm start`. So there is small fixes to simplify it.