### PR TITLE
Fix FileExplorer "About" and favourites links, add createMacBuiltin

### DIFF
--- a/file-explorer/about.html
+++ b/file-explorer/about.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>about FileExpolorer</title>
+    <style type="text/css">
+      html, body, .body {
+        overflow: hidden;
+        text-align: center;
+        font-family: sans-serif;
+        background-image: url('images/htmlbg.png');
+      }
+      a {
+        font-size: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="body">
+      <h3>FileExpolorer sample app</h3>
+      <a href="https://github.com/zcbenz/nw-sample-apps">https://github.com/zcbenz/nw-sample-apps</a>
+    </div>
+  </body>
+</html>

--- a/file-explorer/index.html
+++ b/file-explorer/index.html
@@ -11,14 +11,26 @@
 <body>
 <div style="position: absolute; left: 10px; right: 10px; top: 10px; bottom: 10px;">
   <div class="well" style="float: left; width: 160px; padding: 8px;">
-    <ul class="nav nav-list">
+    <ul class="nav nav-list" id="sidebar">
       <li class="nav-header">Favorites</li>
-      <li class="active"><a href="#"><i class="icon-white icon-home"></i> Home</a></li>
-      <li><a href="#"><i class="icon-book"></i> Documents</a></li>
-      <li><a href="#"><i class="icon-picture"></i> Pictures</a></li>
+      <li class="active">
+        <a href="#" nw-path="~/"><i class="icon-white icon-home"></i> Home</a>
+      </li>
+      <li>
+        <a href="#" nw-path="~/Documents"><i class="icon-book"></i> Documents</a>
+      </li>
+      <li>
+        <a href="#" nw-path="~/Pictures"><i class="icon-picture"></i> Pictures</a>
+      </li>
+      <li>
+        <a href="#" nw-path="~/Music"><i class="icon-music"></i> Music</a>
+      </li>
+      <li>
+        <a href="#" nw-path="~/Movies"><i class="icon-film"></i> Movies</a>
+      </li>
       <li class="nav-header">Network</li>
       <li class="divider"></li>
-      <li><a href="#"><i class="icon-flag"></i> About</a></li>
+      <li><a href="#" nw-call="about" onclick="App.about()"><i class="icon-flag"></i> About</a></li>
     </ul>
   </div>
 

--- a/file-explorer/main.js
+++ b/file-explorer/main.js
@@ -3,24 +3,88 @@ global.$ = $;
 var abar = require('address_bar');
 var folder_view = require('folder_view');
 var path = require('path');
-var shell = require('nw.gui').Shell;
+var nwGui = require('nw.gui');
+
+// append default actions to menu for OSX
+var initMenu = function () {
+  try {
+    var nwGui = require('nw.gui');
+    var nativeMenuBar = new nwGui.Menu({type: "menubar"});
+    if (process.platform == "darwin") {
+      nativeMenuBar.createMacBuiltin && nativeMenuBar.createMacBuiltin("FileExplorer");
+    }
+    nwGui.Window.get().menu = nativeMenuBar;
+  } catch (error) {
+    console.error(error);
+    setTimeout(function () { throw error }, 1);
+  }
+};
+
+var App = {
+  // show "about" window
+  about: function () {
+    var params = {toolbar: false, resizable: false, show: true, height: 120, width: 350};
+    var aboutWindow = nwGui.Window.open('about.html', params);
+    aboutWindow.on('document-end', function() {
+      aboutWindow.focus();
+      // open link in default browser
+      $(aboutWindow.window.document).find('a').bind('click', function (e) {
+        e.preventDefault();
+        nwGui.Shell.openExternal(this.href);
+      });
+    });
+  },
+
+  // change folder for sidebar links
+  cd: function (anchor) {
+    anchor = $(anchor);
+
+    $('#sidebar li').removeClass('active');
+    $('#sidebar i').removeClass('icon-white');
+
+    anchor.closest('li').addClass('active');
+    anchor.find('i').addClass('icon-white');
+
+    this.setPath(anchor.attr('nw-path'));
+  },
+
+  // set path for file explorer
+  setPath: function (path) {
+    if (path.indexOf('~') == 0) {
+      path = path.replace('~', process.env['HOME']);
+    }
+    this.folder.open(path);
+    this.addressbar.set(path);
+  }
+};
 
 $(document).ready(function() {
+  initMenu();
+
   var folder = new folder_view.Folder($('#files'));
   var addressbar = new abar.AddressBar($('#addressbar'));
 
   folder.open(process.cwd());
   addressbar.set(process.cwd());
 
+  App.folder = folder;
+  App.addressbar = addressbar;
+
   folder.on('navigate', function(dir, mime) {
     if (mime.type == 'folder') {
       addressbar.enter(mime);
     } else {
-      shell.openItem(mime.path);
+      nwGui.Shell.openItem(mime.path);
     }
   });
 
   addressbar.on('navigate', function(dir) {
     folder.open(dir);
+  });
+
+  // sidebar favorites
+  $('[nw-path]').bind('click', function (event) {
+    event.preventDefault();
+    App.cd(this);
   });
 });


### PR DESCRIPTION
Fixes #16

I added
* call `menu.createMacBuiltin` when running on mac
* about page in popup window
* make links in sidebar works

![screen shot 2015-05-03 at 15 13 38](https://cloud.githubusercontent.com/assets/26019/7444347/72bf59b2-f1a8-11e4-9934-631dc4627d98.png)

